### PR TITLE
Restore frontpage elements with site configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -171,3 +171,10 @@ map_layers:
     nameProperty: ADM0_NAME
     idProperty: ADM0_CODE
     staticBorders: true
+
+frontpage_goals_grid:
+  title: custom.frontpage_heading
+  description: custom.frontpage_instructions
+frontpage_introduction_banner:
+  title: frontpage.intro_title
+  description: frontpage.intro_body


### PR DESCRIPTION
These site configurations are needed in 2.0.0 in order to display the frontpage elements.