### PR TITLE
Configuration for multilingual logos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll", "3.8.5"
-gem "html-proofer"
+gem "html-proofer", "3.19.4"
 gem "jekyll-remote-theme"
 gem "deep_merge"
 gem "jekyll-open-sdg-plugins", "2.0.0"

--- a/_config.yml
+++ b/_config.yml
@@ -178,3 +178,11 @@ frontpage_goals_grid:
 frontpage_introduction_banner:
   title: frontpage.intro_title
   description: frontpage.intro_body
+
+logos:
+  - language: ru
+    src: assets/img/SDG_logo_ru.png
+    alt: Цели в области устойчивого развития - 17 Целей, чтобы преобразовать наш мир
+  - language: en
+    src: assets/img/SDG_logo_en.png
+    alt: Sustainable Development Goals - 17 Goals to Transform our World


### PR DESCRIPTION
I did not notice before that the previous header.html override was using multilingual logos. This configuration change will recover the language-specific logo images.